### PR TITLE
Rendu : correction du barré

### DIFF
--- a/lib/formats/html.js
+++ b/lib/formats/html.js
@@ -13,7 +13,7 @@ var defaults = {
 		bold: '<b>{content}</b>',
 		italic: '<i>{content}</i>',
 		underline: '<u>{content}</u>',
-		strikethrough: '<s>{content}</s>',
+		strike: '<s>{content}</s>',
 		font: '<span style="font-family:{font}">{content}</span>'
 	},
 	embed: {
@@ -94,7 +94,7 @@ function processLine(line, options, index) {
 				case 'bold':
 				case 'italic':
 				case 'underline':
-				case 'strikethrough':
+				case 'strike':
 				case 'font':
 					node.template = options.styleTags[attr];
 				break;
@@ -137,7 +137,7 @@ function processLine(line, options, index) {
 				case 'underline':
 					node.data.style += cssProp('text-decoration', 'underline');
 				break;
-				case 'strikethrough':
+				case 'strike':
 					node.data.style += cssProp('text-decoration', 'line-through');
 				break;
 				case 'font':


### PR DESCRIPTION
Lors de l'utilisation de quilljs, si on souligne et que l'on barre en même temps, le rendu crash pour afficher le json plutôt que le html.