### PR TITLE
Adaptation de quillrenderer pour les besoins de Dartagnan

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -92,7 +92,6 @@ function lineTypeConvert(delta, func, options) {
 	var lines = [ ];
 
 	newline();
-
 	while (ops.length) {
 		op = ops.shift();
 
@@ -143,8 +142,13 @@ function lineTypeConvert(delta, func, options) {
 		}
 	}
 
+	// remove last line to avoid final <br/>
 	lines.forEach(function(line, index) {
-		content += func(line, options, index);
+		if (index < lines.length - 1) {
+			content += func(line, options, index) + '<br>';
+		} else {
+			content += func(line, options, index);
+		}
 	});
 
 	return content;

--- a/lib/formats/html.js
+++ b/lib/formats/html.js
@@ -4,39 +4,39 @@ var format  = require('stringformat');
 var merge   = require('merge-recursive');
 
 var defaults = {
-	line: '<div id="line-{lineNumber}" style="{lineStyle}">{content}</div>',
+	line: '{content}',
 	text: '<span style="{style}">{content}</span>',
 	link: '<a href="{link}" style="{style}">{content}</a>',
 	styleType: 'html',
 	styleTags: {
 		color: '<span style="color:{color}">{content}</span>',
-		bold: '<b>{content}</b>',
-		italic: '<i>{content}</i>',
-		underline: '<u>{content}</u>',
-		strike: '<s>{content}</s>',
+		bold: '<span style="font-weight:bold">{content}</span>',
+		italic: '<span style="font-style:italic">{content}</span>',
+		underline: '<span style="text-decoration:underline">{content}</span>',
+		strike: '<span style="text-decoration:line-through">{content}</span>',
 		font: '<span style="font-family:{font}">{content}</span>'
 	},
 	scripts: {
-		super: '<sup style="font-family:vertical-align:super;{font}">{content}</sup>'
+		super: '<sup style="font-family:vertical-align:super;">{content}</sup>'
 	},
 	embed: {
 		1: '<img src="{image}" alt="{alt}" />'
 	},
 	attributes: {
-		// 
+		//
 	}
 };
 
 doc.defineFormat('line', 'html', defaults, processLine);
 
-// 
+//
 // Process a single line into HTML
-// 
+//
 // @param {line} the line object, containing ops and attributes
 // @param {options} the options given
 // @param {index} the line index (zero-based)
 // @return string
-// 
+//
 function processLine(line, options, index) {
 	var attrs = Object.keys(line.attributes || { });
 
@@ -46,9 +46,10 @@ function processLine(line, options, index) {
 		content: line.ops.map(contentMap).join('')
 	});
 
-	// 
+
+	//
 	// Builds the content of the line
-	// 
+	//
 	function contentMap(op) {
 		if (typeof op.insert === 'number') {
 			return format(options.embed[op.insert] || '', op.attributes || { });
@@ -66,9 +67,9 @@ function processLine(line, options, index) {
 		}
 	}
 
-	// 
+	//
 	// Builds the style string containing line-level styles (like alignment)
-	// 
+	//
 	function attributeMap(attr) {
 		var value = line.attributes[attr];
 
@@ -79,9 +80,9 @@ function processLine(line, options, index) {
 		}
 	}
 
-	// 
+	//
 	// Render a section of text using style HTML tags like <b> and <i>
-	// 
+	//
 	function drawTextHtml(content, attrs) {
 		Object.keys(attrs).forEach(function(attr) {
 			var node = {
@@ -120,9 +121,9 @@ function processLine(line, options, index) {
 		return content;
 	}
 
-	// 
+	//
 	// Render a section of text using CSS for styling
-	// 
+	//
 	function drawTextCss(content, attrs) {
 		var node = {
 			template: attrs.link ? options.link : options.text,
@@ -164,13 +165,13 @@ function processLine(line, options, index) {
 	}
 }
 
-// 
+//
 // Returns a CSS formatted string
-// 
+//
 // @param {key} the css attribute
 // @param {value} the css attribute value
 // @return string
-// 
+//
 function cssProp(key, value) {
 	return key + ':' + value + ';';
 }


### PR DESCRIPTION
La façon dont quillrenderer retourne les éléments issues du Delta de QuillJS ont été revu pour les besoins de l'élément texte de Dartagnan.